### PR TITLE
Done some refactoring

### DIFF
--- a/Controller/BaseController.php
+++ b/Controller/BaseController.php
@@ -52,9 +52,11 @@ abstract class BaseController extends Controller
 
     /**
      * @return string
+     *
+     * @todo: why does this method exist? it is only used once and the name of the method is ambiguous
      */
     private function getMainClassName() {
-        return $this->getService()->getClassName();
+        return $this->getService()->getEntityClassName();
     }
 
     /**
@@ -73,10 +75,11 @@ abstract class BaseController extends Controller
         );
 
         $params = [
+            'table_alias' => $this->getService()->getTableAlias(),
             'items' => $pagination,
             'routes' => $this->getService()->getRoutes(),
         ];
-        return $this->render($this->getService()->getTemplate('index'), $params);
+        return $this->render($this->getService()->getTemplates()->getIndex(), $params);
     }
 
     /**
@@ -85,6 +88,7 @@ abstract class BaseController extends Controller
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      * @throws \Doctrine\ORM\ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Exception
      */
     protected function processForm(Request $request, $id = null)
     {
@@ -127,7 +131,7 @@ abstract class BaseController extends Controller
             $this->getService()->getEM()->flush();
 
             $this->addFlash('success', 'Der Datensatz wurde erfolgreich gespeichert.');
-            return $this->redirectToRoute($this->getService()->getRoute('index'));
+            return $this->redirectToRoute($this->getService()->getRoutes()->getIndex());
         }
 
         $params = [
@@ -136,9 +140,9 @@ abstract class BaseController extends Controller
             'routes' => $this->getService()->getRoutes(),
         ];
         if (!is_null($id) && $id > 0) {
-            return $this->render($this->getService()->getTemplate('edit'), $params);
+            return $this->render($this->getService()->getTemplates()->getEdit(), $params);
         } else {
-            return $this->render($this->getService()->getTemplate('create'), $params);
+            return $this->render($this->getService()->getTemplates()->getCreate(), $params);
         }
     }
 
@@ -202,6 +206,7 @@ abstract class BaseController extends Controller
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
      * @throws \Doctrine\ORM\ORMException
      * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws \Exception
      */
     public function deleteAction(Request $request, $id)
     {
@@ -219,7 +224,7 @@ abstract class BaseController extends Controller
             $this->getService()->getEM()->remove($obj);
             $this->getService()->getEM()->flush();
 
-            return $this->redirectToRoute($this->getService()->getRoute('index'));
+            return $this->redirectToRoute($this->getService()->getRoutes()->getIndex());
         }
 
         $params = [
@@ -227,7 +232,7 @@ abstract class BaseController extends Controller
             'obj' => $obj,
             'form' => $form->createView(),
         ];
-        return $this->render($this->getService()->getTemplate('delete'), $params);
+        return $this->render($this->getService()->getTemplates()->getDelete(), $params);
     }
 
     /**

--- a/Model/Routes.php
+++ b/Model/Routes.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace webworks\CoreBundle\Model;
+
+class Routes implements RoutesInterface
+{
+    private $index;
+    private $create;
+    private $edit;
+    private $delete;
+
+    /**
+     * @return mixed
+     */
+    public function getIndex()
+    {
+        return $this->index;
+    }
+
+    /**
+     * @param $index
+     * @return $this
+     */
+    public function setIndex($index)
+    {
+        $this->index = $index;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCreate()
+    {
+        return $this->create;
+    }
+
+    /**
+     * @param mixed $create
+     * @return $this
+     */
+    public function setCreate($create)
+    {
+        $this->create = $create;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getEdit()
+    {
+        return $this->edit;
+    }
+
+    /**
+     * @param mixed $edit
+     * @return $this
+     */
+    public function setEdit($edit)
+    {
+        $this->edit = $edit;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDelete()
+    {
+        return $this->delete;
+    }
+
+    /**
+     * @param mixed $delete
+     * @return $this
+     */
+    public function setDelete($delete)
+    {
+        $this->delete = $delete;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRouteKeys()
+    {
+        $data = [];
+        foreach ( $this as $keyName => $value) {
+            $data[] = $keyName;
+        }
+        return $data;
+    }
+}

--- a/Model/RoutesInterface.php
+++ b/Model/RoutesInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace webworks\CoreBundle\Model;
+
+interface RoutesInterface
+{
+    /**
+     * @return string
+     */
+    public function getIndex();
+    /**
+     * @param string $index
+     * @return $this
+     */
+    public function setIndex($index);
+    /**
+     * @return string
+     */
+    public function getCreate();
+    /**
+     * @param string $create
+     * @return $this
+     */
+    public function setCreate($create);
+    /**
+     * @return string
+     */
+    public function getEdit();
+    /**
+     * @param string $edit
+     * @return $this
+     */
+    public function setEdit($edit);
+    /**
+     * @return string
+     */
+    public function getDelete();
+    /**
+     * @param string $delete
+     * @return $this
+     */
+    public function setDelete($delete);
+    /**
+     * @return array
+     */
+    public function getRouteKeys();
+}

--- a/Model/Templates.php
+++ b/Model/Templates.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace webworks\CoreBundle\Model;
+
+class Templates implements TemplatesInterface
+{
+    private $index;
+    private $create;
+    private $edit;
+    private $delete;
+
+    /**
+     * @return mixed
+     */
+    public function getIndex()
+    {
+        return $this->index;
+    }
+
+    /**
+     * @param $index
+     * @return $this
+     */
+    public function setIndex($index)
+    {
+        $this->index = $index;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCreate()
+    {
+        return $this->create;
+    }
+
+    /**
+     * @param mixed $create
+     * @return $this
+     */
+    public function setCreate($create)
+    {
+        $this->create = $create;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getEdit()
+    {
+        return $this->edit;
+    }
+
+    /**
+     * @param mixed $edit
+     * @return $this
+     */
+    public function setEdit($edit)
+    {
+        $this->edit = $edit;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDelete()
+    {
+        return $this->delete;
+    }
+
+    /**
+     * @param mixed $delete
+     * @return $this
+     */
+    public function setDelete($delete)
+    {
+        $this->delete = $delete;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRouteKeys()
+    {
+        $data = [];
+        foreach ( $this as $keyName => $value) {
+            $data[] = $keyName;
+        }
+        return $data;
+    }
+}

--- a/Model/TemplatesInterface.php
+++ b/Model/TemplatesInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace webworks\CoreBundle\Model;
+
+interface TemplatesInterface
+{
+    /**
+     * @return string
+     */
+    public function getIndex();
+    /**
+     * @param string $index
+     * @return $this
+     */
+    public function setIndex($index);
+    /**
+     * @return string
+     */
+    public function getCreate();
+    /**
+     * @param string $create
+     * @return $this
+     */
+    public function setCreate($create);
+    /**
+     * @return string
+     */
+    public function getEdit();
+    /**
+     * @param string $edit
+     * @return $this
+     */
+    public function setEdit($edit);
+    /**
+     * @return string
+     */
+    public function getDelete();
+    /**
+     * @param string $delete
+     * @return $this
+     */
+    public function setDelete($delete);
+    /**
+     * @return array
+     */
+    public function getRouteKeys();
+}


### PR DESCRIPTION
- routes are not anymore passed as a undefined array but as a RoutesInterface
- templates are not anymore passed as a undefined array but as a TemplatesInterface
- the BaseService can now get some data by himself
- the BaseService can now create the Form by himself

modified file /Service/BaseService.php
- renamed abstract method getClassName() to getEntityClassName() because that is what the method is expected to do
- changed abstract method getAll() to be not abstract and implement it
- changed abstract method getOneById() to be not abstract and implement it
- changed abstract method getForm() to be not abstract and implement it
- changed abstract method getTemplates() to be not abstract and implement it
- changed abstract method getRoutes() to be not abstract and implement it

- removed getTemplate() method, because the getTemplates() method returns now a TemplatesInterface that has predefined methods to access the properties. There is no need to access properties by magic names
- removed getRoute() method, because the getRoutes() method returns now a RoutesInterface that has predefined methods to access the properties. There is no need to access properties by magic names

- added abstract method getFormClassName() to generate more content automatically
- added abstract method getRoutesConfig() which will be called if a route is requested.
- added abstract method getTemplatesConfig() which will be called if a template is requested.
- added method validateRoutes() to check if the passed routes are valid
- added method validateTemplates() to check if the passed templates are valid
- added method getTableAlias() so the Bundle User can define the alias that will be used in the templates by himself

modified file /Controller/BaseController.php
- minor modifications to fit to the refactored service

added files:
- /Model/Routes.php
- /Model/RoutesInterface.php
- /Model/Templates.php
- /Model/TemplatesInterface.php